### PR TITLE
Add YouTube transcript extension

### DIFF
--- a/.github/extensions/youtube-transcript/extension.mjs
+++ b/.github/extensions/youtube-transcript/extension.mjs
@@ -1,0 +1,159 @@
+// YouTube Transcript Extension
+// Fetches captions/transcripts from YouTube videos to use as context.
+// Uses only built-in Node.js APIs — no npm dependencies required.
+import { joinSession } from "@github/copilot-sdk/extension";
+
+// Prevent unhandled rejections from silently crashing the extension process
+process.on("unhandledRejection", () => {});
+
+function extractVideoId(input) {
+    const patterns = [
+        /(?:youtube\.com\/watch\?(?:.*&)?v=)([a-zA-Z0-9_-]{11})/,
+        /(?:youtu\.be\/)([a-zA-Z0-9_-]{11})/,
+        /(?:youtube\.com\/embed\/)([a-zA-Z0-9_-]{11})/,
+        /(?:youtube\.com\/shorts\/)([a-zA-Z0-9_-]{11})/,
+        /^([a-zA-Z0-9_-]{11})$/,
+    ];
+    for (const pattern of patterns) {
+        const m = input.trim().match(pattern);
+        if (m) return m[1];
+    }
+    return null;
+}
+
+// Robustly extract a top-level JSON object assigned to a JS variable in a page.
+function extractJsonObject(html, varName) {
+    const marker = `var ${varName} = `;
+    const start = html.indexOf(marker);
+    if (start === -1) return null;
+
+    const jsonStart = html.indexOf("{", start + marker.length);
+    if (jsonStart === -1) return null;
+
+    let depth = 0;
+    let inString = false;
+    let escape = false;
+
+    for (let i = jsonStart; i < html.length; i++) {
+        const c = html[i];
+        if (escape) { escape = false; continue; }
+        if (c === "\\" && inString) { escape = true; continue; }
+        if (c === '"') { inString = !inString; continue; }
+        if (inString) continue;
+        if (c === "{") depth++;
+        else if (c === "}") {
+            depth--;
+            if (depth === 0) return html.substring(jsonStart, i + 1);
+        }
+    }
+    return null;
+}
+
+function decodeCaptionXml(xml) {
+    const texts = [];
+    const re = /<text\b[^>]*>([^<]*)<\/text>/g;
+    let m;
+    while ((m = re.exec(xml)) !== null) {
+        const t = m[1]
+            .replace(/&amp;/g, "&")
+            .replace(/&lt;/g, "<")
+            .replace(/&gt;/g, ">")
+            .replace(/&quot;/g, '"')
+            .replace(/&#39;/g, "'")
+            .replace(/\n/g, " ")
+            .trim();
+        if (t) texts.push(t);
+    }
+    return texts.join(" ");
+}
+
+async function getTranscript(videoUrl) {
+    const videoId = extractVideoId(videoUrl);
+    if (!videoId) throw new Error(`Cannot extract video ID from: ${videoUrl}`);
+
+    const pageRes = await fetch(`https://www.youtube.com/watch?v=${videoId}`, {
+        headers: {
+            "User-Agent":
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+            "Accept-Language": "en-US,en;q=0.9",
+            Cookie: "CONSENT=YES+cb.20210328-17-p0.en+FX+299",
+        },
+    });
+
+    if (!pageRes.ok) throw new Error(`HTTP ${pageRes.status} fetching video page`);
+
+    const html = await pageRes.text();
+    const jsonStr = extractJsonObject(html, "ytInitialPlayerResponse");
+    if (!jsonStr) throw new Error("Could not find ytInitialPlayerResponse in page — YouTube may have changed its structure");
+
+    const playerData = JSON.parse(jsonStr);
+    const tracks = playerData?.captions?.playerCaptionsTracklistRenderer?.captionTracks;
+    if (!tracks?.length) throw new Error("No captions available for this video (captions may be disabled or unavailable)");
+
+    // Prefer English manual captions, then English auto-generated, then first available
+    const track =
+        tracks.find((t) => t.languageCode === "en" && t.kind !== "asr") ||
+        tracks.find((t) => t.languageCode === "en") ||
+        tracks[0];
+
+    const captionRes = await fetch(track.baseUrl + "&fmt=xml");
+    if (!captionRes.ok) throw new Error(`HTTP ${captionRes.status} fetching captions`);
+
+    const xml = await captionRes.text();
+    const transcript = decodeCaptionXml(xml);
+
+    const title = playerData?.videoDetails?.title ?? "Unknown";
+    const author = playerData?.videoDetails?.author ?? "Unknown";
+    const lengthSeconds = playerData?.videoDetails?.lengthSeconds;
+    const duration = lengthSeconds
+        ? `${Math.floor(lengthSeconds / 60)}m ${lengthSeconds % 60}s`
+        : "Unknown";
+
+    return { videoId, title, author, duration, language: track.languageCode, transcript };
+}
+
+const session = await joinSession({
+    tools: [
+        {
+            name: "get_youtube_transcript",
+            description:
+                "Fetches the transcript (captions) from a YouTube video and returns it as text to use as context. " +
+                "Accepts YouTube URLs (youtube.com/watch?v=..., youtu.be/..., YouTube Shorts) or a raw 11-character video ID.",
+            parameters: {
+                type: "object",
+                properties: {
+                    url: {
+                        type: "string",
+                        description: "YouTube video URL or 11-character video ID",
+                    },
+                },
+                required: ["url"],
+            },
+            handler: async (args) => {
+                await session.log(`Fetching YouTube transcript for: ${args.url}`, { ephemeral: true });
+                try {
+                    const { videoId, title, author, duration, language, transcript } =
+                        await getTranscript(args.url);
+                    const wordCount = transcript.split(/\s+/).filter(Boolean).length;
+                    await session.log(
+                        `✓ Transcript fetched: "${title}" — ${wordCount} words (lang: ${language})`
+                    );
+                    return [
+                        "# YouTube Transcript",
+                        `**Video ID:** ${videoId}`,
+                        `**Title:** ${title}`,
+                        `**Channel:** ${author}`,
+                        `**Duration:** ${duration}`,
+                        `**Language:** ${language}`,
+                        "",
+                        "## Transcript",
+                        transcript,
+                    ].join("\n");
+                } catch (err) {
+                    await session.log(`✗ Failed to fetch transcript: ${err.message}`, { level: "error" });
+                    return { textResultForLlm: `Error: ${err.message}`, resultType: "failure" };
+                }
+            },
+        },
+    ],
+});

--- a/.github/extensions/youtube-transcript/extension.mjs
+++ b/.github/extensions/youtube-transcript/extension.mjs
@@ -1,116 +1,10 @@
-// YouTube Transcript Extension
-// Fetches captions/transcripts from YouTube videos to use as context.
-// Uses only built-in Node.js APIs — no npm dependencies required.
+// YouTube Transcript — Copilot CLI Extension entry point.
+// Core logic lives in .github/skills/youtube-transcript/fetch-transcript.mjs.
 import { joinSession } from "@github/copilot-sdk/extension";
+import { getTranscript, formatTranscript } from "../../skills/youtube-transcript/fetch-transcript.mjs";
 
 // Prevent unhandled rejections from silently crashing the extension process
 process.on("unhandledRejection", () => {});
-
-function extractVideoId(input) {
-    const patterns = [
-        /(?:youtube\.com\/watch\?(?:.*&)?v=)([a-zA-Z0-9_-]{11})/,
-        /(?:youtu\.be\/)([a-zA-Z0-9_-]{11})/,
-        /(?:youtube\.com\/embed\/)([a-zA-Z0-9_-]{11})/,
-        /(?:youtube\.com\/shorts\/)([a-zA-Z0-9_-]{11})/,
-        /^([a-zA-Z0-9_-]{11})$/,
-    ];
-    for (const pattern of patterns) {
-        const m = input.trim().match(pattern);
-        if (m) return m[1];
-    }
-    return null;
-}
-
-// Robustly extract a top-level JSON object assigned to a JS variable in a page.
-function extractJsonObject(html, varName) {
-    const marker = `var ${varName} = `;
-    const start = html.indexOf(marker);
-    if (start === -1) return null;
-
-    const jsonStart = html.indexOf("{", start + marker.length);
-    if (jsonStart === -1) return null;
-
-    let depth = 0;
-    let inString = false;
-    let escape = false;
-
-    for (let i = jsonStart; i < html.length; i++) {
-        const c = html[i];
-        if (escape) { escape = false; continue; }
-        if (c === "\\" && inString) { escape = true; continue; }
-        if (c === '"') { inString = !inString; continue; }
-        if (inString) continue;
-        if (c === "{") depth++;
-        else if (c === "}") {
-            depth--;
-            if (depth === 0) return html.substring(jsonStart, i + 1);
-        }
-    }
-    return null;
-}
-
-function decodeCaptionXml(xml) {
-    const texts = [];
-    const re = /<text\b[^>]*>([^<]*)<\/text>/g;
-    let m;
-    while ((m = re.exec(xml)) !== null) {
-        const t = m[1]
-            .replace(/&amp;/g, "&")
-            .replace(/&lt;/g, "<")
-            .replace(/&gt;/g, ">")
-            .replace(/&quot;/g, '"')
-            .replace(/&#39;/g, "'")
-            .replace(/\n/g, " ")
-            .trim();
-        if (t) texts.push(t);
-    }
-    return texts.join(" ");
-}
-
-async function getTranscript(videoUrl) {
-    const videoId = extractVideoId(videoUrl);
-    if (!videoId) throw new Error(`Cannot extract video ID from: ${videoUrl}`);
-
-    const pageRes = await fetch(`https://www.youtube.com/watch?v=${videoId}`, {
-        headers: {
-            "User-Agent":
-                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-            "Accept-Language": "en-US,en;q=0.9",
-            Cookie: "CONSENT=YES+cb.20210328-17-p0.en+FX+299",
-        },
-    });
-
-    if (!pageRes.ok) throw new Error(`HTTP ${pageRes.status} fetching video page`);
-
-    const html = await pageRes.text();
-    const jsonStr = extractJsonObject(html, "ytInitialPlayerResponse");
-    if (!jsonStr) throw new Error("Could not find ytInitialPlayerResponse in page — YouTube may have changed its structure");
-
-    const playerData = JSON.parse(jsonStr);
-    const tracks = playerData?.captions?.playerCaptionsTracklistRenderer?.captionTracks;
-    if (!tracks?.length) throw new Error("No captions available for this video (captions may be disabled or unavailable)");
-
-    // Prefer English manual captions, then English auto-generated, then first available
-    const track =
-        tracks.find((t) => t.languageCode === "en" && t.kind !== "asr") ||
-        tracks.find((t) => t.languageCode === "en") ||
-        tracks[0];
-
-    const captionRes = await fetch(track.baseUrl + "&fmt=xml");
-    if (!captionRes.ok) throw new Error(`HTTP ${captionRes.status} fetching captions`);
-
-    const xml = await captionRes.text();
-    const transcript = decodeCaptionXml(xml);
-
-    const title = playerData?.videoDetails?.title ?? "Unknown";
-    const author = playerData?.videoDetails?.author ?? "Unknown";
-    const lengthSeconds = playerData?.videoDetails?.lengthSeconds;
-    const duration = lengthSeconds
-        ? `${Math.floor(lengthSeconds / 60)}m ${lengthSeconds % 60}s`
-        : "Unknown";
-
-    return { videoId, title, author, duration, language: track.languageCode, transcript };
-}
 
 const session = await joinSession({
     tools: [
@@ -132,23 +26,12 @@ const session = await joinSession({
             handler: async (args) => {
                 await session.log(`Fetching YouTube transcript for: ${args.url}`, { ephemeral: true });
                 try {
-                    const { videoId, title, author, duration, language, transcript } =
-                        await getTranscript(args.url);
-                    const wordCount = transcript.split(/\s+/).filter(Boolean).length;
+                    const result = await getTranscript(args.url);
+                    const wordCount = result.transcript.split(/\s+/).filter(Boolean).length;
                     await session.log(
-                        `✓ Transcript fetched: "${title}" — ${wordCount} words (lang: ${language})`
+                        `✓ Transcript fetched: "${result.title}" — ${wordCount} words (lang: ${result.language})`
                     );
-                    return [
-                        "# YouTube Transcript",
-                        `**Video ID:** ${videoId}`,
-                        `**Title:** ${title}`,
-                        `**Channel:** ${author}`,
-                        `**Duration:** ${duration}`,
-                        `**Language:** ${language}`,
-                        "",
-                        "## Transcript",
-                        transcript,
-                    ].join("\n");
+                    return formatTranscript(result);
                 } catch (err) {
                     await session.log(`✗ Failed to fetch transcript: ${err.message}`, { level: "error" });
                     return { textResultForLlm: `Error: ${err.message}`, resultType: "failure" };

--- a/.github/skills/youtube-transcript/SKILL.md
+++ b/.github/skills/youtube-transcript/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: youtube-transcript
+description: Fetches the transcript (captions) from a YouTube video to use as context. Use this when the user provides a YouTube URL or video ID and wants to reference, summarise, or ask questions about the video's content.
+argument-hint: <YouTube URL or video ID>
+---
+
+# YouTube Transcript
+
+When the user provides a YouTube video URL or ID and wants to work with the video's content, fetch the transcript using the included script and use the output as context.
+
+## When to use this skill
+
+- The user pastes a YouTube link and asks questions about it
+- The user wants to summarise, translate, or extract information from a YouTube video
+- The user references a YouTube video as background context for a task
+
+## Steps
+
+1. Extract the video URL or ID from the user's message.
+2. Run the fetch script to download the transcript:
+
+   ```bash
+   node .github/skills/youtube-transcript/fetch-transcript.mjs "<YouTube URL or video ID>"
+   ```
+
+3. The script prints the transcript to stdout in this format:
+   ```
+   # YouTube Transcript
+   **Title:** ...
+   **Channel:** ...
+   **Duration:** ...
+   **Language:** ...
+
+   ## Transcript
+   <full transcript text>
+   ```
+
+4. Read the output and use the full transcript as context to answer the user's request.
+
+## Notes
+
+- The script requires Node.js 18+ (uses built-in `fetch`).
+- It works with `youtube.com/watch?v=`, `youtu.be/`, `/embed/`, `/shorts/`, or a raw 11-character video ID.
+- If captions are unavailable (disabled by the uploader), the script exits with an error message — let the user know.
+- Prefer English captions when available; the script falls back to the first available language.
+
+## Script reference
+
+See [fetch-transcript.mjs](./fetch-transcript.mjs) for the full implementation.

--- a/.github/skills/youtube-transcript/fetch-transcript.mjs
+++ b/.github/skills/youtube-transcript/fetch-transcript.mjs
@@ -1,0 +1,140 @@
+// Shared YouTube transcript fetching logic.
+// Can be imported as a module (exports getTranscript, formatTranscript) or run directly as a CLI script.
+// Requires Node.js 18+ for built-in fetch.
+import { fileURLToPath } from "node:url";
+
+export function extractVideoId(input) {
+    const patterns = [
+        /(?:youtube\.com\/watch\?(?:.*&)?v=)([a-zA-Z0-9_-]{11})/,
+        /(?:youtu\.be\/)([a-zA-Z0-9_-]{11})/,
+        /(?:youtube\.com\/embed\/)([a-zA-Z0-9_-]{11})/,
+        /(?:youtube\.com\/shorts\/)([a-zA-Z0-9_-]{11})/,
+        /^([a-zA-Z0-9_-]{11})$/,
+    ];
+    for (const pattern of patterns) {
+        const m = input.trim().match(pattern);
+        if (m) return m[1];
+    }
+    return null;
+}
+
+// Robustly extract a top-level JSON object assigned to a JS variable in a page.
+function extractJsonObject(html, varName) {
+    const marker = `var ${varName} = `;
+    const start = html.indexOf(marker);
+    if (start === -1) return null;
+
+    const jsonStart = html.indexOf("{", start + marker.length);
+    if (jsonStart === -1) return null;
+
+    let depth = 0;
+    let inString = false;
+    let escape = false;
+
+    for (let i = jsonStart; i < html.length; i++) {
+        const c = html[i];
+        if (escape) { escape = false; continue; }
+        if (c === "\\" && inString) { escape = true; continue; }
+        if (c === '"') { inString = !inString; continue; }
+        if (inString) continue;
+        if (c === "{") depth++;
+        else if (c === "}") {
+            depth--;
+            if (depth === 0) return html.substring(jsonStart, i + 1);
+        }
+    }
+    return null;
+}
+
+function decodeCaptionXml(xml) {
+    const texts = [];
+    const re = /<text\b[^>]*>([^<]*)<\/text>/g;
+    let m;
+    while ((m = re.exec(xml)) !== null) {
+        const t = m[1]
+            .replace(/&amp;/g, "&")
+            .replace(/&lt;/g, "<")
+            .replace(/&gt;/g, ">")
+            .replace(/&quot;/g, '"')
+            .replace(/&#39;/g, "'")
+            .replace(/\n/g, " ")
+            .trim();
+        if (t) texts.push(t);
+    }
+    return texts.join(" ");
+}
+
+export async function getTranscript(videoUrl) {
+    const videoId = extractVideoId(videoUrl);
+    if (!videoId) throw new Error(`Cannot extract video ID from: ${videoUrl}`);
+
+    const pageRes = await fetch(`https://www.youtube.com/watch?v=${videoId}`, {
+        headers: {
+            "User-Agent":
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+            "Accept-Language": "en-US,en;q=0.9",
+            Cookie: "CONSENT=YES+cb.20210328-17-p0.en+FX+299",
+        },
+    });
+
+    if (!pageRes.ok) throw new Error(`HTTP ${pageRes.status} fetching video page`);
+
+    const html = await pageRes.text();
+    const jsonStr = extractJsonObject(html, "ytInitialPlayerResponse");
+    if (!jsonStr) throw new Error("Could not find ytInitialPlayerResponse in page — YouTube may have changed its structure");
+
+    const playerData = JSON.parse(jsonStr);
+    const tracks = playerData?.captions?.playerCaptionsTracklistRenderer?.captionTracks;
+    if (!tracks?.length) throw new Error("No captions available for this video (captions may be disabled or unavailable)");
+
+    // Prefer English manual captions, then English auto-generated, then first available
+    const track =
+        tracks.find((t) => t.languageCode === "en" && t.kind !== "asr") ||
+        tracks.find((t) => t.languageCode === "en") ||
+        tracks[0];
+
+    const captionRes = await fetch(track.baseUrl + "&fmt=xml");
+    if (!captionRes.ok) throw new Error(`HTTP ${captionRes.status} fetching captions`);
+
+    const xml = await captionRes.text();
+    const transcript = decodeCaptionXml(xml);
+
+    const title = playerData?.videoDetails?.title ?? "Unknown";
+    const author = playerData?.videoDetails?.author ?? "Unknown";
+    const lengthSeconds = playerData?.videoDetails?.lengthSeconds;
+    const duration = lengthSeconds
+        ? `${Math.floor(lengthSeconds / 60)}m ${lengthSeconds % 60}s`
+        : "Unknown";
+
+    return { videoId, title, author, duration, language: track.languageCode, transcript };
+}
+
+export function formatTranscript({ videoId, title, author, duration, language, transcript }) {
+    return [
+        "# YouTube Transcript",
+        `**Video ID:** ${videoId}`,
+        `**Title:** ${title}`,
+        `**Channel:** ${author}`,
+        `**Duration:** ${duration}`,
+        `**Language:** ${language}`,
+        "",
+        "## Transcript",
+        transcript,
+    ].join("\n");
+}
+
+// CLI entry point — only runs when executed directly, not when imported as a module
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+    const url = process.argv[2];
+    if (!url) {
+        console.error("Usage: node fetch-transcript.mjs <YouTube URL or video ID>");
+        process.exit(1);
+    }
+    try {
+        const result = await getTranscript(url);
+        console.log(formatTranscript(result));
+    } catch (err) {
+        console.error(`Error: ${err.message}`);
+        process.exit(1);
+    }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent Instructions
+
+See [.github/copilot-instructions.md](.github/copilot-instructions.md) for the full agent/Copilot instructions for this repository.


### PR DESCRIPTION
## What

Adds a YouTube transcript capability with two entry points sharing the same core logic.

## Structure

```
.github/
  skills/youtube-transcript/
    SKILL.md               ← Agent Skills definition (VS Code Copilot Chat, CLI, cloud agent)
    fetch-transcript.mjs   ← Shared core logic + CLI script
  extensions/youtube-transcript/
    extension.mjs          ← Copilot CLI extension (thin wrapper, imports from shared module)
```

## How it works

`fetch-transcript.mjs` is the single source of truth. It:
- Exports `getTranscript(url)` and `formatTranscript(result)` for module imports
- Runs as a CLI script when executed directly: `node fetch-transcript.mjs <url>`
- Fetches `ytInitialPlayerResponse` from the YouTube page (brace-counting JSON extraction)
- Picks the best caption track (English manual → English auto-generated → first available)
- Parses caption XML and returns title, channel, duration, language, and full transcript

**VS Code Copilot Chat** — loads `SKILL.md` automatically when you reference a YouTube video; runs the script via the terminal tool.

**Copilot CLI extension** — registers a `get_youtube_transcript` tool that calls the shared module directly.

**Supported URL formats:** `watch?v=`, `youtu.be/`, `/embed/`, `/shorts/`, raw 11-char video ID. No npm dependencies.

## Also

Added `AGENTS.md` pointing to `.github/copilot-instructions.md`.