### PR TITLE
Add Books and LinkedIn Learning course pages

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -29,6 +29,8 @@
 						<li><a href="{{ "/blog/tools" | absolute_url }}" target="_blank">Tools</a></li>
 						<li><a href="{{ "/blog/atom.xml" | absolute_url }}" target="_blank">RSS</a></li>
 						<li><a href="https://mailchi.mp/a94a59145fe3/rajbos_github_io" target="_blank">Subscribe</a></li>
+						<li><a href="{{ "/blog/published-books" | absolute_url }}" target="_blank">Books</a></li>
+						<li><a href="{{ "/blog/linkedin-learning" | absolute_url }}" target="_blank">Courses</a></li>
 						<li><a href="{{ "/blog/about" | absolute_url }}" target="_blank">About</a></li>
 					</ul>                    
 					</div><!-- /.navbar-collapse -->

--- a/blog/linkedin-learning.md
+++ b/blog/linkedin-learning.md
@@ -1,0 +1,72 @@
+---
+layout: default
+title: LinkedIn Learning Courses
+---
+<style>
+  .main-panel{padding:12px}
+  .course-grid{display:flex;flex-wrap:wrap;gap:24px;margin-top:16px;}
+  .course-card{flex:1 1 280px;max-width:380px;border:1px solid #ddd;border-radius:6px;overflow:hidden;box-shadow:2px 2px 6px rgba(0,0,0,.1);}
+  .course-card img{width:100%;display:block;}
+  .course-card-body{padding:12px 16px 16px;}
+  .course-card-body h3{margin-top:0;font-size:1.05rem;}
+  .course-card-body a.cta{display:inline-block;margin-top:8px;padding:6px 14px;background:#0077B5;color:#fff;border-radius:4px;text-decoration:none;font-size:.9rem;}
+  .course-card-body a.cta:hover{background:#005885;}
+</style>
+
+<div class="panel panel-default well-sm main-panel" markdown="1">
+
+# LinkedIn Learning Courses 🎓
+
+I'm a LinkedIn Learning Instructor. Below are the courses I've published. Click any course to view it on LinkedIn Learning.
+
+[![LinkedIn Learning Logo](/images/LinkedIn_Learning/LinkedIn_Learning_Logo.png)](https://www.linkedin.com/learning/instructors/rob-bos){:target="_blank"}
+
+---
+
+<div class="course-grid">
+
+  <div class="course-card">
+    <img src="/images/LinkedIn_Learning/GitHub_Advanced_Security_02_500x281.png" alt="GitHub Advanced Security course thumbnail" />
+    <div class="course-card-body">
+      <h3>GitHub Advanced Security</h3>
+      <p>Learn how to protect your codebase with GitHub Advanced Security — secret scanning, code scanning, and Dependabot.</p>
+      <a class="cta" href="/blog/2022/10/19/LinkedIn-Learning-GHAS" target="_blank">View course</a>
+    </div>
+  </div>
+
+  <div class="course-card">
+    <img src="/images/LinkedIn_Learning/GitHub_Advanced_Security_500x274.png" alt="GitHub Advanced Security for Azure DevOps course thumbnail" />
+    <div class="course-card-body">
+      <h3>GitHub Advanced Security for Azure DevOps</h3>
+      <p>Bring GitHub Advanced Security capabilities to Azure DevOps — code scanning, secret detection, and dependency review in your existing pipelines.</p>
+      <a class="cta" href="https://www.linkedin.com/learning/learning-github-advanced-security-for-azure-devops/" target="_blank">View course</a>
+    </div>
+  </div>
+
+  <div class="course-card">
+    <div class="course-card-body" style="padding-top:16px;">
+      <h3>25 GitHub Configuration Files You Should Be Using</h3>
+      <p>A hands-on tour of the most useful GitHub configuration files that improve your repositories, workflows, and developer experience.</p>
+      <a class="cta" href="https://www.linkedin.com/learning/25-github-configuration-files-you-should-be-using" target="_blank">View course</a>
+    </div>
+  </div>
+
+  <div class="course-card">
+    <div class="course-card-body" style="padding-top:16px;">
+      <h3>Enterprise AI Development with GitHub Models and Azure</h3>
+      <p>Build enterprise-grade AI applications using GitHub Models and Azure, covering API integration, prompt engineering, and responsible AI practices.</p>
+      <a class="cta" href="https://www.linkedin.com/learning/enterprise-ai-development-with-github-models-and-azure/ai-with-github-models" target="_blank">View course</a>
+    </div>
+  </div>
+
+  <div class="course-card">
+    <div class="course-card-body" style="padding-top:16px;">
+      <h3>Responsible GitHub Copilot: Creating Reliable Code Ethically</h3>
+      <p>Understand how to use GitHub Copilot responsibly — writing reliable, ethical, and high-quality code with AI assistance.</p>
+      <a class="cta" href="https://www.linkedin.com/learning/responsible-github-copilot-creating-reliable-code-ethically-24981582/genai-and-creating-code-responsibly" target="_blank">View course</a>
+    </div>
+  </div>
+
+</div>
+
+</div>

--- a/blog/published-books.md
+++ b/blog/published-books.md
@@ -1,0 +1,75 @@
+---
+layout: default
+title: Books I Co-authored
+---
+<style>
+  .main-panel{padding:12px}
+  .book-row{display:flex;flex-wrap:wrap;gap:24px;margin-bottom:32px;align-items:flex-start;}
+  .book-cover{flex:0 0 auto;}
+  .book-cover img{max-width:200px;border:1px solid #ddd;border-radius:4px;box-shadow:2px 2px 6px rgba(0,0,0,.15);}
+  .book-info{flex:1 1 300px;}
+  .book-info h2{margin-top:0;}
+  .buy-links{margin-top:12px;}
+  .buy-links a{display:inline-block;margin-right:12px;margin-top:6px;}
+  @media(max-width:600px){
+    .book-cover img{max-width:140px;}
+  }
+</style>
+
+<div class="panel panel-default well-sm main-panel" markdown="1">
+
+# Books I've Co-authored 📚
+
+These are books I've co-authored and published. Both are available at the links below.
+
+---
+
+<div class="book-row">
+  <div class="book-cover">
+    <a href="https://www.manning.com/books/github-actions-in-action" target="_blank">
+      <img src="/images/Books/2024-GitHubActionsInAction.png" alt="Cover of GitHub Actions in Action" />
+    </a>
+  </div>
+  <div class="book-info" markdown="1">
+
+## GitHub Actions in Action
+
+**Continuous integration and delivery for DevOps**  
+*Published by Manning Publications*
+
+Continuous delivery (CI/CD) pipelines help you automate the software development process and maximize your team's efficiency. *GitHub Actions in Action* teaches you how to build, test, and deploy pipelines in GitHub Actions through hands-on labs and projects.
+
+<div class="buy-links">
+  <a href="https://www.manning.com/books/github-actions-in-action" target="_blank">Buy at Manning</a>
+  <a href="https://www.amazon.com/GitHub-Actions-Action-Continuous-integration/dp/1633437302/" target="_blank">Buy at Amazon</a>
+</div>
+  </div>
+</div>
+
+---
+
+<div class="book-row">
+  <div class="book-cover">
+    <a href="https://www.packtpub.com/en-us/product/the-github-copilot-handbook-9781806116638" target="_blank">
+      <img src="/images/Books/2025-TheGitHubCopilotHandBook.png" alt="Cover of The GitHub Copilot Handbook" />
+    </a>
+  </div>
+  <div class="book-info" markdown="1">
+
+## The GitHub Copilot Handbook
+
+**A practical guide to transforming the software development life cycle with GitHub Copilot**  
+*Published by Packt Publishing*
+
+Cross-functional product teams are under constant pressure to build and ship faster, but too much time is lost to manual coding, slow reviews, and fragmented workflows. Written together with Randy Pagels, this book shows how GitHub Copilot supports your work from start to finish — turning ideas into tasks, writing code with fewer hiccups, spotting problems earlier, and understanding errors when things go wrong.
+
+You'll integrate GitHub Copilot into daily routines, share it across roles, and track what works. By the end, you'll know when GitHub Copilot helps — and when it doesn't — and you'll be ready to write, review, and ship code with confidence.
+
+<div class="buy-links">
+  <a href="https://www.packtpub.com/en-us/product/the-github-copilot-handbook-9781806116638" target="_blank">Buy at Packt</a>
+  <a href="https://www.amazon.com/Mastering-GitHub-Copilot-programming-collaboration/dp/1806116634/" target="_blank">Buy at Amazon</a>
+</div>
+  </div>
+</div>
+
+</div>


### PR DESCRIPTION
Adds two new dedicated pages and nav menu items.

## Changes

- **\log/published-books.md\** — showcases the two co-authored books (*GitHub Actions in Action* and *The GitHub Copilot Handbook*) with cover images, descriptions, and buy links for Manning/Packt/Amazon
- **\log/linkedin-learning.md\** — lists all 5 LinkedIn Learning courses as cards with thumbnails, descriptions, and direct links to each course
- **\_layouts/default.html\** — adds **Books** and **Courses** nav items before About