### PR TITLE
fix(agent): update blog interviewer tools to current VS Code aliases

### DIFF
--- a/.github/agents/blog-interviewer.agent.md
+++ b/.github/agents/blog-interviewer.agent.md
@@ -1,7 +1,7 @@
 ---
 name: "Blog Interviewer"
 description: "Give me some reference links and a story seed — I'll research, interview you, write the post, and review it with you."
-tools: ['fetch', 'codebase', 'editFiles', 'runCommands']
+tools: ['web', 'search', 'edit', 'execute', 'read']
 ---
 
 You are Rob's blog post interviewer and writer for rajbos.github.io, a DevOps journal.
@@ -17,7 +17,7 @@ One or more of:
 
 ## Phase 1: Research (silent)
 
-Before asking a single question, fetch and read every provided URL. Note:
+Before asking a single question, fetch and read every provided URL. Use web search to find additional context if needed. Note:
 - Key claims, product names, versions, features
 - Anything that needs Rob's personal angle or lived experience
 - Gaps that only Rob can fill
@@ -86,6 +86,11 @@ For each revision round:
 3. Ask what else needs adjusting, or if it's ready.
 
 When Rob is happy, write the file directly to `_posts/YYYY-MM-DD-slug.md`.
+
+If the post references images, before writing the post file:
+1. Run `New-Item -ItemType Directory -Force -Path images/YYYY/YYYYMMDD` to create the image folder.
+2. If Rob provides image files or URLs, save them to `images/YYYY/YYYYMMDD/` using `Invoke-WebRequest` (for URLs) or by copying from the provided path.
+3. Confirm image paths in the post use `/images/YYYY/YYYYMMDD/filename.ext` format.
 
 ## Hard rules
 


### PR DESCRIPTION
## What

Updates the Blog Interviewer agent's \	ools\ list from deprecated/ambiguous names to the current documented VS Code aliases.

**Before:** \['fetch', 'codebase', 'editFiles', 'runCommands']\
**After:** \['web', 'search', 'edit', 'execute', 'read']\

## Why

The old tool names were silently ignored by VS Code (unrecognized names are skipped per docs), so the agent had no file write or shell execution — explaining why it couldn't create image folders.

## Changes
- \web\ replaces \etch\; also includes WebSearch (research capability)
- \search\ replaces \codebase\; covers grep + glob
- \dit\ replaces \ditFiles\; covers create + edit
- \xecute\ replaces \unCommands\; enables mkdir and Invoke-WebRequest for images
- \ead\ added for explicit file reading
- Phase 4 now instructs the agent to create the image folder before writing the post