### PR TITLE
Fix Xebia logo: crop to match MVP height, remove border

### DIFF
--- a/blog/about.md
+++ b/blog/about.md
@@ -112,7 +112,7 @@ Me:<br />
 ![Rob](/images/Rob_OnStage.png)
 
 I work at Xebia <br />
-[![Xpirit Expert Blog](/images/xebia_logo_label_smaller.png)](https://xebia.com)  
+<a href="https://xebia.com"><img src="/images/xebia_logo_label_smaller.png" alt="Xebia" style="width:100%;aspect-ratio:180.3/72.8;object-fit:cover;border:none;border-radius:0;" /></a>
 
 Microsoft MVP since 2020 <br />
 [![MVP](/images/MVP.svg)](https://mvp.microsoft.com/en-us/PublicProfile/5003719)


### PR DESCRIPTION
Fixes the about page sidebar:\n\n- Crops the Xebia logo to the same aspect ratio as the MVP banner using \object-fit: cover\, so both logos render at the same height\n- Removes the silver border from the Xebia image